### PR TITLE
Add publish and updated dates to pages.

### DIFF
--- a/src/components/PreviewCollectionItem.astro
+++ b/src/components/PreviewCollectionItem.astro
@@ -1,6 +1,8 @@
 ---
 import { format } from "date-fns";
 import render_markdown from "@src/utils/remark";
+import PublishedUpdatedFragment from "./PublishedUpdatedFragment.astro";
+
 const { slug } = Astro.props;
 const { title, excerpt, prefix, published, lastUpdated } = Astro.props.data;
 ---
@@ -12,48 +14,16 @@ const { title, excerpt, prefix, published, lastUpdated } = Astro.props.data;
       `### ${title} {#${prefix.replace("/", "_")}${slug}}`,
     )}
   />
-  <div>
-    <span
-      >Published: <time datetime={published.toISOString()}
-        >{format(published, "dd MMMM yyyy")}</time
-      ></span
-    >
-    {
-      lastUpdated && (
-        <>
-          <span>
-            Last Updated:
-            <time datetime={lastUpdated.toISOString()}>
-              {format(lastUpdated, "dd MMMM yyyy")}
-            </time>
-          </span>
-        </>
-      )
-    }
-  </div>
+  <PublishedUpdatedFragment published={published} updated={lastUpdated} />
   <p set:html={excerpt} />
 </article>
 
 <style>
-  span {
-    color: var(--color-subtext0);
-    font-size: var(--size-font-subtext0);
-  }
-
   article {
     margin-top: 9px;
     display: grid;
     grid-template-columns: 1fr;
     gap: 6px;
-  }
-
-  div {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    /* grid-template-columns: repeat(auto-fit, 25ch); */
-    column-gap: 12px;
-    row-gap: 6px;
   }
 
   article * {

--- a/src/components/PublishedUpdatedFragment.astro
+++ b/src/components/PublishedUpdatedFragment.astro
@@ -1,0 +1,41 @@
+---
+import { format } from "date-fns";
+
+const { published, updated } = Astro.props;
+---
+
+<div>
+  <span>
+    Published:{" "}
+    <time datetime={published.toISOString()}>
+      {format(published, "dd MMMM yyyy")}
+    </time>
+  </span>
+  {
+    updated && (
+      <>
+        <span>
+          Last Updated:
+          <time datetime={updated.toISOString()}>
+            {format(updated, "dd MMMM yyyy")}
+          </time>
+        </span>
+      </>
+    )
+  }
+</div>
+
+<style>
+  div {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: 12px;
+    row-gap: 6px;
+  }
+
+  span {
+    color: var(--color-subtext0);
+    font-size: var(--size-font-subtext0);
+  }
+</style>

--- a/src/pages/[...pages].astro
+++ b/src/pages/[...pages].astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 
 import Layout from "@src/layouts/Layout.astro";
 import render_markdown from "@src/utils/remark";
+import PublishUpdatedFragment from "@components/PublishedUpdatedFragment.astro";
 
 export async function getStaticPaths() {
   const pages = [
@@ -23,5 +24,7 @@ const title = render_markdown(`# ${entry.data.title}`);
 
 <Layout title={entry.data.title} description={entry.data.excerpt}>
   <Fragment set:html={title} />
+  <PublishUpdatedFragment published={entry.data.published} updated={entry.data.lastUpdated} />
+
   <Content />
 </Layout>


### PR DESCRIPTION
People should be able to see when a page was published and updates, so that they can tell if it's likely outdated or not.

It also helps automatic tools to judge the page or get extra metadata. For example zbib.org when trying to create citing information for a page.