### PR TITLE
Add related pages functionality

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import SectionDivider from "@components/SectionDivider.astro";
+
 const { class: className, title, url } = Astro.props;
 const reportURL = encodeURI(
   `https://github.com/AliciaBytes/aliciabytes.com/issues/new?template=broken-page.yml&title=Broken page: ${title}&url=${url}`,
@@ -7,7 +9,7 @@ const reportURL = encodeURI(
 
 <footer class={className} id="footer">
   <a class="tap-target" id="report-page" href={reportURL}>Report broken page</a>
-  <hr />
+  <SectionDivider />
   <div class="footer-sections">
     <div class="social-section">
       <a class="tap-target" rel="me" href="https://tech.lgbt/@AliciaBytes"
@@ -58,9 +60,6 @@ const reportURL = encodeURI(
   #report-page {
     color: var(--color-overlay0);
     margin: 9px 0;
-  }
-  hr {
-    margin: 9px 0 0 0;
   }
   .footer-sections {
     margin: 9px 0 18px 0;

--- a/src/components/LinkedPostList.astro
+++ b/src/components/LinkedPostList.astro
@@ -1,0 +1,42 @@
+---
+import { getEntry, type CollectionKey } from "astro:content";
+
+import Preview from "@components/PreviewCollectionItem.astro";
+import SectionDivider from "./SectionDivider.astro";
+
+let { related_items, description } = Astro.props;
+
+let entries = [];
+if (related_items) {
+  for (const item of related_items) {
+    const entry = await getEntry(item.collection as CollectionKey, item.id);
+    entries.push(entry);
+  }
+}
+
+console.log(entries);
+
+description ??= "Related pages";
+---
+
+{
+  related_items && related_items.length != 0 && (
+    <section>
+      <h2>{description}</h2>
+      <ul>
+        {entries.map((page) => (
+          <li>
+            <Preview {...page} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+<style>
+  ul {
+    list-style-type: none;
+    padding: 0;
+  }
+</style>

--- a/src/components/PreviewCollectionItem.astro
+++ b/src/components/PreviewCollectionItem.astro
@@ -1,5 +1,4 @@
 ---
-import { format } from "date-fns";
 import render_markdown from "@src/utils/remark";
 import PublishedUpdatedFragment from "./PublishedUpdatedFragment.astro";
 

--- a/src/components/SectionDivider.astro
+++ b/src/components/SectionDivider.astro
@@ -1,0 +1,11 @@
+---
+
+---
+
+<hr />
+
+<style>
+  hr {
+    margin: 9px 0 0 0;
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -22,8 +22,14 @@ const pages = defineCollection({
     lastUpdated: z.date().optional(),
     tags: z.array(z.string()),
     categories: z.array(z.string()).optional(),
-    relatedPages: z.array(reference('pages')),
-    backlinks: z.array(reference('pages')),
+    relatedPages: z.array(z.object({
+      collection: z.string(),
+      id: z.string(),
+    })).optional(),
+    backlinks: z.array(z.object({
+      collection: z.string(),
+      id: z.string(),
+    })).optional(),
     aliases: z.array(z.string()).optional(),
   })
 });
@@ -38,8 +44,14 @@ const notes = defineCollection({
     lastUpdated: z.date().optional(),
     tags: z.array(z.string()),
     categories: z.array(z.string()).optional(),
-    relatedPages: z.array(reference('notes')),
-    backlinks: z.array(reference('notes')),
+    relatedPages: z.array(z.object({
+      collection: z.string(),
+      id: z.string(),
+    })).optional(),
+    backlinks: z.array(z.object({
+      collection: z.string(),
+      id: z.string(),
+    })).optional(),
     aliases: z.array(z.string()).optional(),
   })
 });

--- a/src/content/notes/Kobo.md
+++ b/src/content/notes/Kobo.md
@@ -4,8 +4,6 @@ excerpt: Some notes on using Kobo
 slug: kobo
 published: 2024-05-19
 tags: []
-relatedPages: []
-backlinks: []
 ---
 ## Using Custom Fonts
 

--- a/src/content/notes/til-ansible-linger.md
+++ b/src/content/notes/til-ansible-linger.md
@@ -4,8 +4,6 @@ excerpt: Systemd only starts up after the login of a user and then immediately g
 slug: til-systemd-lingering-with-ansible
 published: 2024-04-18
 tags: ["Ansible"]
-relatedPages: []
-backlinks: []
 ---
 
 Systemd only starts up after the login of a user and then immediately gets killed again when all the sessions for that user get closed. Let's look at how to disable this with ansible. But systemd is an important part necessary for a lot of programs and services on a Linux system. For example systemd timers won't run without it and you also can't run podman containers as they would get killed when systemd gets killed with the end of the users session.

--- a/src/content/pages/a-guide-to-alicias-heart-emojis.md
+++ b/src/content/pages/a-guide-to-alicias-heart-emojis.md
@@ -4,8 +4,6 @@ excerpt: I'm gonna go and wear my heart on my sleeve here. I'm already always pr
 slug: a-guide-to-alicias-heart-emojis
 published: 2024-05-23
 tags: ["Emotions"]
-relatedPages: []
-backlinks: []
 ---
 
 I'm gonna go and wear my heart on my sleeve here. I'm already always pretty open about myself. And I try to be open about intentions, although one can always do better. But that's not the topic here. The topic is my heart. Well, at least my heart emojis. I'm a very weird and quirky woman. I don't know how common it is for others, but I have a bunch of meanings for the different heart emojis and colors. And why not share that little quirky bit about me?

--- a/src/content/pages/behind-the-scenes-of-my-website.md
+++ b/src/content/pages/behind-the-scenes-of-my-website.md
@@ -5,8 +5,6 @@ slug: behind-the-scenes-of-my-website
 published: 2023-08-13
 lastUpdated: 2024-05-19
 tags: []
-relatedPages: []
-backlinks: []
 ---
 
 First off, don't expect this to be a well thought out amazing piece of work. I'm not a frontend developer, UI or design person, I prefer to stay on the code side on the back end. My website is quirky and imperfect and missing features because of other more important projects. But it's my little space on the internet. And that's important. With the internet becoming more and more polluted with ads, walled in communities that lock up information, AI plagiarizing and stealing content, etc. I felt that I need my own place even more now.

--- a/src/content/pages/bits-bytes-nibbles-the-hungry-developers-guide-to-binary.mdx
+++ b/src/content/pages/bits-bytes-nibbles-the-hungry-developers-guide-to-binary.mdx
@@ -5,8 +5,6 @@ slug: bits-bytes-nibbles-the-hungry-developers-guide-to-binary
 published: 2024-02-07
 # lastUpdated: 2024-02-06
 tags: []
-relatedPages: []
-backlinks: []
 ---
 
 import { Picture } from 'astro:assets';

--- a/src/content/pages/cheesecake-with-mandarins.mdx
+++ b/src/content/pages/cheesecake-with-mandarins.mdx
@@ -4,9 +4,6 @@ excerpt: Recipe for a cheesecake with Mandarins, one of my favorite cakes growin
 slug: cheesecake-with-mandarins
 published: 2024-05-25
 tags: []
-relatedPages: []
-backlinks: []
-aliases: []
 ---
 
 import { Picture } from 'astro:assets';

--- a/src/content/pages/cron-default-permission-inconsistencies.md
+++ b/src/content/pages/cron-default-permission-inconsistencies.md
@@ -4,8 +4,6 @@ excerpt: In Linux even basic standard tooling that many people assume are the sa
 slug: cron-default-permission-inconsistencies
 published: 2022-10-22
 tags: ["Linux"]
-relatedPages: []
-backlinks: []
 ---
 
 In Linux even basic standard tooling that many people assume are the same across distributions, can behave differently and have inconsistencies. Sometimes standards like POSIX aren't detailed enough or people just plainly interpret them differently. This blog post is based on weird inconsistencies I found while studying for the LPIC-1 certificate at my vocational school.

--- a/src/content/pages/how-sql-many-to-many-relationships-work.mdx
+++ b/src/content/pages/how-sql-many-to-many-relationships-work.mdx
@@ -4,8 +4,6 @@ excerpt: Many Object-Relational Mappers (ORMs) allow you to just declare a Many-
 slug: how-sql-many-to-many-relationships-work
 published: 2023-11-01
 tags: ["SQL"]
-relatedPages: []
-backlinks: []
 ---
 
 import RemoteSVG from '@src/components/RemoteSVG.astro';

--- a/src/content/pages/lost-years-of-my-past.mdx
+++ b/src/content/pages/lost-years-of-my-past.mdx
@@ -4,8 +4,7 @@ excerpt: "Shedding light on all the \"lost\" years in my past and what's actuall
 slug: lost-years-of-my-past
 published: 2023-11-07
 tags: ["Mental Health"]
-relatedPages: []
-backlinks: []
+backlinks: [{collection: "pages", id: "unashamedly-being-myself-everywhere"}]
 ---
 
 import InlineSpoiler from '@src/components/InlineSpoiler.astro';

--- a/src/content/pages/recommendations.md
+++ b/src/content/pages/recommendations.md
@@ -5,8 +5,6 @@ slug: recommendations
 published: 2024-02-05
 lastUpdated: 2024-02-06
 tags: []
-relatedPages: []
-backlinks: []
 aliases: ["/things-i-enjoy-and-recommend/"]
 ---
 

--- a/src/content/pages/unashamedly-being-myself.md
+++ b/src/content/pages/unashamedly-being-myself.md
@@ -4,8 +4,7 @@ excerpt: Being unashamedly myself everywhere. Work, privately, publicly.
 slug: unashamedly-being-myself-everywhere
 published: 2024-06-15
 tags: ["Identity"]
-relatedPages: []
-backlinks: []
+relatedPages: [{collection: "pages", id: "lost-years-of-my-past"}]
 ---
 
 I need to let out my feelings and talk about what it means to be unashamedly myself. What it means to myself. Why I want to do it and it's important to me. What my fears about it and some negative consequences are. But also the positive consequences for me (and hopefully also others around me).

--- a/src/content/pages/why-i-love-my-ereader.mdx
+++ b/src/content/pages/why-i-love-my-ereader.mdx
@@ -4,8 +4,6 @@ excerpt: Why I love my E-Reader and why I love blog posts on it.
 slug: why-i-love-my-ereader
 published: 2024-03-25
 tags: []
-relatedPages: []
-backlinks: []
 ---
 
 import { Picture } from 'astro:assets';

--- a/src/pages/[...pages].astro
+++ b/src/pages/[...pages].astro
@@ -3,7 +3,10 @@ import { getCollection } from "astro:content";
 
 import Layout from "@src/layouts/Layout.astro";
 import render_markdown from "@src/utils/remark";
+
 import PublishUpdatedFragment from "@components/PublishedUpdatedFragment.astro";
+import LinkedPostList from "@src/components/LinkedPostList.astro";
+import SectionDivider from "@components/SectionDivider.astro";
 
 export async function getStaticPaths() {
   const pages = [
@@ -24,7 +27,22 @@ const title = render_markdown(`# ${entry.data.title}`);
 
 <Layout title={entry.data.title} description={entry.data.excerpt}>
   <Fragment set:html={title} />
-  <PublishUpdatedFragment published={entry.data.published} updated={entry.data.lastUpdated} />
+  <PublishUpdatedFragment
+    published={entry.data.published}
+    updated={entry.data.lastUpdated}
+  />
 
   <Content />
+
+  {(entry.data.relatedPages || entry.data.backlinks) && <SectionDivider />}
+
+  <LinkedPostList
+    description="Related pages"
+    related_items={entry.data.relatedPages}
+  />
+
+  <LinkedPostList
+    description="Pages linking here"
+    related_items={entry.data.backlinks}
+  />
 </Layout>


### PR DESCRIPTION
Add the functionality to show related pages at the bottom of a page. This also includes showing other pages that link to this page.

For this we also touched the schema and all the pages to clean up the metadata we need to get page information across collections.